### PR TITLE
Expand customization options of create command

### DIFF
--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -113,7 +113,11 @@ module LXC
           raise ArgumentError, "File #{path[:config_file]} does not exist." if !File.exists?(path[:config_file])
           args += " -f #{path[:config_file]}"
         end
-        args += " -t #{path[:template]}" if !!path[:template]
+        if !!path[:template]
+          template_path = "/usr/lib/lxc/templates/lxc-#{path[:template]}"
+          raise ArgumentError, "Template #{path[:template]} does not exist." if !File.exists?(template_path)
+          args += " -t #{path[:template]}"
+        end
         args += " -B #{path[:backingstore]}" if !!path[:backingstore]
         args += " #{path[:template_options].join(' ')}".strip if !!path[:template_options]
         LXC.run('create', args)

--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -104,11 +104,23 @@ module LXC
     end
 
     # Create a new container
-    # @param [String] path to container config file
+    # @param [String] path to container config file or [Hash] options
     def create(path)
-      raise ArgumentError, "File #{path} does not exist." if !File.exists?(path)
       raise ContainerError, "Container already exists." if exists?
-      LXC.run('create', '-n', name, '-f', path)
+      if path.is_a?(Hash)
+        args = "-n #{name}"
+        if !!path[:config_file]
+          raise ArgumentError, "File #{path[:config_file]} does not exist." if !File.exists?(path[:config_file])
+          args += " -f #{path[:config_file]}"
+        end
+        args += " -t #{path[:template]}" if !!path[:template]
+        args += " -B #{path[:backingstore]}" if !!path[:backingstore]
+        args += " #{path[:template_options].join(' ')}".strip if !!path[:template_options]
+        LXC.run('create', args)
+      else
+        raise ArgumentError, "File #{path} does not exist." if !File.exists?(path)
+        LXC.run('create', '-n', name, '-f', path)
+      end
     end
 
     # Destroy the container 


### PR DESCRIPTION
- Accept arguments to lxc-create per format described at
  http://manpages.ubuntu.com/manpages/precise/man1/lxc-create.1.html
- Example:

``` ruby
  c = LXC::Container.new('foo')
  c.create({:config_file => path_to_lxc_config, :template => 'ubuntu'})
  lxc-create -n foo -f path_to_lxc_config -t ubuntu
```
