### PR TITLE
Container#cpu_usage and Container#cpu_shares should return nil if Container#run command returns nil

### DIFF
--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -111,17 +111,15 @@ module LXC
     # Get container cpu shares
     # @return [Integer]
     def cpu_shares
-      result = run('cgroup', "cpu.shares")
-      result.strip! if result
-      result.nil? || result.empty? ? nil : result.to_i
+      result = run('cgroup', "cpu.shares").to_s.strip
+      result.empty? ? nil : result.to_i
     end
 
     # Get container cpu usage in seconds
     # @return [Float]
     def cpu_usage
-      result = run('cgroup', "cpuacct.usage")
-      result.strip! if result
-      result.nil? || result.empty? ? nil : Float('%.4f' % (result.to_i / 1E9))
+      result = run('cgroup', "cpuacct.usage").to_s.strip
+      result.empty? ? nil : Float('%.4f' % (result.to_i / 1E9))
     end
 
     # Get container processes

--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -111,15 +111,17 @@ module LXC
     # Get container cpu shares
     # @return [Integer]
     def cpu_shares
-      result = run('cgroup', "cpu.shares").strip
-      result.empty? ? nil : result.to_i
+      result = run('cgroup', "cpu.shares")
+      result.strip! if result
+      result.nil? || result.empty? ? nil : result.to_i
     end
 
     # Get container cpu usage in seconds
     # @return [Float]
     def cpu_usage
-      result = run('cgroup', "cpuacct.usage").strip
-      result.empty? ? nil : Float('%.4f' % (result.to_i / 1E9))
+      result = run('cgroup', "cpuacct.usage")
+      result.strip! if result
+      result.nil? || result.empty? ? nil : Float('%.4f' % (result.to_i / 1E9))
     end
 
     # Get container processes

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -141,6 +141,16 @@ describe LXC::Container do
         subject.cpu_shares.should be_nil
       end
     end
+
+    context 'when run command is nil' do
+      before do
+        subject.stub!(:run).and_return(nil)
+      end
+
+      it 'should return nil' do
+        subject.cpu_shares.should be_nil
+      end
+    end
   end
 
   describe '#cpu_usage' do
@@ -160,6 +170,16 @@ describe LXC::Container do
       end
 
       it 'returns nil' do
+        subject.cpu_usage.should be_nil
+      end
+    end
+
+    context 'when run command is nil' do
+      before do
+        subject.stub!(:run).and_return(nil)
+      end
+
+      it 'should return nil' do
         subject.cpu_usage.should be_nil
       end
     end


### PR DESCRIPTION
NoMethodError - undefined method `strip' for nil:NilClass - is thrown
when calling Container#cpu_usage and Container#cpu_shares if
Container#run returns nil.
