### PR TITLE
Allow passing template directory while creating containers

### DIFF
--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -158,7 +158,8 @@ module LXC
         end
 
         if !!path[:template]
-          template_path = "/usr/lib/lxc/templates/lxc-#{path[:template]}"
+          template_dir =  path[:template_dir] || '/usr/lib/lxc/templates'
+          template_path = File.join(template_dir,"lxc-#{path[:template]}")
           unless File.exists?(template_path)
             raise ArgumentError, "Template #{path[:template]} does not exist."
           end


### PR DESCRIPTION
Currently the lxc template directory is hard coded inside the create method. Since different linux distros place lxc templates in different locations (e.g fedora places it in /usr/share/lxc, and ubuntu inside /usr/lib/lxc) this method fails sometime. This PR will let users pass template directory as additional option, to circumvent this, in absence of this option it will fall back to the current hard coded value, thus retaining the old behavior. 
