### PR TITLE
Support detecting underlying lxc native library version

### DIFF
--- a/lib/lxc/shell.rb
+++ b/lib/lxc/shell.rb
@@ -62,6 +62,12 @@ module LXC
       val
     end
 
+    # Obtain the installed lxc version
+    # @return [String] installed native lxc library version
+    def version
+      run("version")
+    end
+
     # Check if container state is valid
     # @param name [String] container name
     # @return [Boolean]


### PR DESCRIPTION
lxc-info output is changed on 1.0.0 alpha release. since we parse this output for detecting status, pid etc , `container.status` breaks. This will allow detecting the underlying lxc version and take appropriate measures.
